### PR TITLE
Setup npm tooling for scribejs use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+_site/

--- a/.scribejs.json
+++ b/.scribejs.json
@@ -1,0 +1,5 @@
+{
+  "group": "pwg",
+  "nicknames": "assets/nicknames.json",
+  "jekyll": "kd"
+}

--- a/README.md
+++ b/README.md
@@ -20,3 +20,42 @@ Use the standard fork, branch, and pull request workflow to propose changes to t
 Editorial changes that improve the readability of the spec or correct spelling or grammatical mistakes are welcome.
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md), about licensing contributions.
+
+## Tools
+
+Generating weekly minutes is done via the
+[scribejs](https://github.com/w3c/scribejs) script and some additional
+configuration settings provided in this repo (see `.scribejs.json`).
+
+To use this repository's scribejs setup first install the tools...
+
+```bash
+$ npm install
+```
+
+Then run the following (with date
+information changed to match your scenario):
+
+```bash
+$ npm run scribejs -- -d 2018-07-09 -o Meetings/Minutes/2018/2018-07-09-pwg.md
+```
+
+This will request the IRC logs for the correct channel and convert them into
+the Kramdown (a more feature rich form of Markdown) with settings to match this
+repositories other documents.
+
+If you need to make edits to the IRC log before generating the output (due to
+incorrect scribenick or similar), you can download the W3C logs from URLs such
+as `https://www.w3.org/2018/07/09-pwg-irc.txt`. Once downloaded, you can
+reference that input document directly (rather than using the automagic
+date-based retrieval).
+
+For example:
+
+```bash
+$ curl https://www.w3.org/2018/07/09-pwg-irc.txt > 2018-07-09-pwg-irc.txt
+$ npm run scribejs -- 2018-07-09-pwg-irc.txt -d 2018-07-09 -o Meetings/Minutes/2018/2018-07-09-pwg.md
+```
+Edit the .txt file and repeat the `npm run scribejs` line as necessary. Once
+finished, you can commit the `.md` file and delete the `.txt` file (or keep it
+for your records).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,188 @@
+{
+  "name": "publ-wg",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ajv": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+      "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.1"
+      }
+    },
+    "commander": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
+      "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fetch-vcr": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fetch-vcr/-/fetch-vcr-1.1.2.tgz",
+      "integrity": "sha512-bFOx3+5YtViximcqhG05tqMlsyPRXNOmiToDCf6TyVUCKHYP/vGPmn0HUhGVNd1jI0KpElwz+RH3X/ZQo0Asfg==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.6.3",
+        "whatwg-fetch": "^2.0.3"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "dev": true
+    },
+    "moment": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
+      "dev": true
+    },
+    "octokat": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/octokat/-/octokat-0.10.0.tgz",
+      "integrity": "sha512-VJ21L1gMlByYMurduLYiOcI8AwlZkUV8OXRN8pMXsbkIqIVqn0tgdTfxzWM9spX4VJTTG02OgqwDTqQsOmDing==",
+      "dev": true,
+      "requires": {
+        "fetch-vcr": "^1.1.0",
+        "lodash": "^4.16.4",
+        "node-fetch": "^2.0.0"
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "scribejs": {
+      "version": "git+https://github.com/w3c/scribejs.git#f662bda2a5dc37f31bce86c36d5529f7ff5dad78",
+      "from": "git+https://github.com/w3c/scribejs.git",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.1.1",
+        "commander": "^2.9.0",
+        "moment": "^2.21.0",
+        "node-fetch": "^2.1.2",
+        "octokat": "^0.10.0",
+        "safe-regex": "^1.1.0",
+        "underscore": "^1.8.3",
+        "valid-url": "^1.0.9"
+      }
+    },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
+      "dev": true
+    },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "private": true,
+  "name": "publ-wg",
+  "version": "0.1.0",
+  "description": "Node tooling for the Publishing Working Group site",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "scribejs": "scribejs -c .scribejs.json"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/w3c/publ-wg.git"
+  },
+  "keywords": [
+    "W3C",
+    "publishing"
+  ],
+  "author": "W3C Members",
+  "license": "W3C-20150513",
+  "bugs": {
+    "url": "https://github.com/w3c/publ-wg/issues"
+  },
+  "homepage": "https://github.com/w3c/publ-wg#readme",
+  "devDependencies": {
+    "scribejs": "git+https://github.com/w3c/scribejs.git"
+  }
+}


### PR DESCRIPTION
Documented basic weekly usage.
Added default settings to .scribejs.json
Setup private npm module for installing all the things.

I've been working on learning @iherman's [scribejs](https://github.com/w3c/scribejs) tool for the JSON-LD WG and am helping @TzviyaSiegman today with this week's Publishing WG minutes.

This is some local setup and instructions that should help @TzviyaSiegman and @GarthConboy more easily generate minutes themselves if/as needed--like when @iherman is on vacation (and not checking his email!! :wink:).

The README seemed like the best place to keep these instructions--let me know if you'd like them elsewhere.

Cheers!
🎩 